### PR TITLE
Atualização scripts limpeza v4.1.0 e correção v4.0.0 bases SEI e SIP

### DIFF
--- a/mysql/v4.1.0/utilitarios/sei_script_limpeza_mysql.sql
+++ b/mysql/v4.1.0/utilitarios/sei_script_limpeza_mysql.sql
@@ -1,0 +1,341 @@
+/*
+SCRIPT DE LIMPEZA DE PROCESSOS, DOCUMENTOS E OPERAÇÕES DE USUÁRIOS DA BASE DE DADOS DO SEI 4.1.0 (MySQL)    
+	Antes de executar o script:
+		1) Retirar o sistema do "AR" (derrubar todas sessões).
+		2) Fazer uma cópia da base imediatamente antes de executar o script.
+		3) Executar o script de limpeza. Se der erro, restaurar a base com a cópia feita no passo 2.
+	
+	Depois de executar o script com sucesso, sendo aconselhável conferir algumas tabelas abaixo e sequenciais de protocolo de processo na tabela "infra_sequencia":
+		1) Apagar todos os arquivos e estrutura de pastas no Filesystem do SEI.
+		2) Excluir os índices do Solr, conforme orientado no final do capítulo do Solr no Manual de Instalação do SEI:
+			18 - Caso,  no  futuro,  seja  preciso  reindexar  todos  os  dados  é  aconselhável  limpar  antes  os  índices usando os comandos abaixo:
+				http://[servidor_solr]:8080/solr/sei-protocolos/update?stream.body=<delete><query>*:*</query></delete>&commit=true
+				http://[servidor_solr]:8080/solr/sei-bases-conhecimento/update?stream.body=<delete><query>*:*</query></delete>&commit=true
+				http://[servidor_solr]:8080/solr/sei-publicacoes/update?stream.body=<delete><query>*:*</query></delete>&commit=true
+		4) Colocar o sistema de volta ao "AR".
+*/
+
+use sei;
+
+/* Limpeza de tabelas afetas a Protocolo de Processos, de Documentos Gerados e Externos e de Operações dos Usuários */
+
+SET FOREIGN_KEY_CHECKS=0;
+
+truncate table anexo;
+truncate table seq_anexo;
+
+truncate table numeracao;
+truncate table seq_numeracao;
+
+truncate table acesso;
+truncate table seq_acesso;
+
+truncate table acesso_externo;
+truncate table seq_acesso_externo;
+
+truncate table acompanhamento;
+truncate table seq_acompanhamento;
+
+truncate table grupo_acompanhamento;
+truncate table seq_grupo_acompanhamento;
+
+truncate table andamento_situacao;
+truncate table seq_andamento_situacao;
+
+truncate table anotacao;
+truncate table seq_anotacao;
+
+truncate table assinatura;
+truncate table seq_assinatura;
+
+truncate table estatisticas;
+truncate table seq_estatisticas;
+
+truncate table base_conhecimento;
+truncate table seq_base_conhecimento;
+
+truncate table rel_base_conhec_tipo_proced;
+
+truncate table versao_secao_documento;
+truncate table seq_versao_secao_documento;
+
+truncate table secao_documento;
+truncate table seq_secao_documento;
+
+truncate table atributo_andamento;
+truncate table seq_atributo_andamento;
+
+truncate table retorno_programado;
+truncate table seq_retorno_programado;
+
+truncate table participante;
+truncate table seq_participante;
+
+truncate table observacao;
+truncate table seq_observacao;
+
+truncate table rel_protocolo_assunto;
+
+truncate table rel_protocolo_protocolo;
+truncate table seq_rel_protocolo_protocolo;
+
+truncate table publicacao;
+truncate table seq_publicacao;
+
+truncate table rel_bloco_protocolo;
+
+truncate table rel_bloco_unidade;
+
+truncate table protocolo_modelo;
+truncate table seq_protocolo_modelo;
+
+truncate table grupo_protocolo_modelo;
+truncate table seq_grupo_protocolo_modelo;
+
+truncate table unidade_publicacao;
+truncate table seq_unidade_publicacao;
+
+truncate table serie_escolha;
+
+truncate table serie_publicacao;
+truncate table seq_serie_publicacao;
+
+truncate table texto_padrao_interno;
+truncate table seq_texto_padrao_interno;
+
+truncate table rel_protocolo_atributo;
+
+truncate table feed;
+truncate table seq_feed;
+
+truncate table seq_atributo_andamento_situaca;
+
+truncate table auditoria_protocolo;
+truncate table seq_auditoria_protocolo;
+
+truncate table rel_notificacao_documento;
+
+truncate table notificacao;
+
+truncate table bloco;
+truncate table seq_bloco;
+
+truncate table atividade;
+truncate table seq_atividade;
+
+truncate table documento;
+truncate table seq_documento;
+
+truncate table procedimento;
+
+truncate table tipo_procedimento_escolha;
+
+truncate table protocolo;
+truncate table seq_protocolo;
+
+truncate table email_grupo_email;
+truncate table seq_email_grupo_email;
+
+truncate table grupo_email;
+truncate table seq_grupo_email;
+
+truncate table acao_federacao;
+
+truncate table acesso_federacao;
+
+truncate table andamento_instalacao;
+truncate table seq_andamento_instalacao;
+
+truncate table andamento_marcador;
+truncate table seq_andamento_marcador;
+
+truncate table seq_andamento_situacao;
+
+truncate table arquivamento;
+
+truncate table atributo_instalacao;
+truncate table seq_atributo_instalacao;
+
+truncate table campo_pesquisa;
+truncate table seq_campo_pesquisa;
+
+truncate table categoria;
+truncate table seq_categoria;
+
+truncate table comentario;
+truncate table seq_comentario;
+
+truncate table controle_prazo;
+truncate table seq_controle_prazo;
+
+truncate table documento_conteudo;
+
+truncate table grupo_bloco;
+truncate table seq_grupo_bloco;
+
+truncate table grupo_federacao;
+truncate table seq_grupo_federacao;
+
+truncate table instalacao_federacao;
+
+truncate table lembrete;
+truncate table seq_lembrete;
+
+truncate table mapeamento_assunto;
+
+truncate table marcador;
+truncate table seq_marcador;
+
+truncate table monitoramento_servico;
+truncate table seq_monitoramento_servico;
+
+truncate table orgao_federacao;
+
+truncate table parametro_acao_federacao;
+
+truncate table pesquisa;
+truncate table seq_pesquisa;
+
+truncate table protocolo_federacao;
+
+truncate table rel_acesso_ext_protocolo;
+
+truncate table rel_acesso_ext_serie;
+
+truncate table rel_grupo_fed_orgao_fed;
+
+truncate table rel_usuario_grupo_acomp;
+
+truncate table rel_usuario_grupo_bloco;
+
+truncate table rel_usuario_marcador;
+
+truncate table rel_usuario_tipo_proced;
+
+truncate table rel_usuario_usuario_unidade;
+
+truncate table replicacao_federacao;
+
+truncate table sinalizacao_federacao;
+
+truncate table unidade_federacao;
+
+truncate table usuario_federacao;
+
+truncate table andamento_plano_trabalho;
+truncate table seq_andamento_plano_trabalho;
+
+truncate table atributo_andam_plano_trab;
+truncate table seq_atributo_andam_plano_trab;
+
+truncate table avaliacao_documental;
+truncate table seq_avaliacao_documental;
+
+truncate table aviso;
+truncate table seq_aviso;
+
+truncate table cpad;
+truncate table seq_cpad;
+
+truncate table cpad_avaliacao;
+truncate table seq_cpad_avaliacao;
+
+truncate table cpad_composicao;
+truncate table seq_cpad_composicao;
+
+truncate table cpad_versao;
+truncate table seq_cpad_versao;
+
+truncate table documento_geracao;
+
+truncate table edital_eliminacao;
+truncate table seq_edital_eliminacao;
+
+truncate table edital_eliminacao_conteudo;
+truncate table seq_edital_eliminacao_conteudo;
+
+truncate table edital_eliminacao_erro;
+truncate table seq_edital_eliminacao_erro;
+
+truncate table etapa_trabalho;
+truncate table seq_etapa_trabalho;
+
+truncate table infra_captcha;
+
+truncate table infra_captcha_tentativa;
+
+truncate table infra_erro_php;
+
+truncate table item_etapa;
+truncate table seq_item_etapa;
+
+truncate table notificacao;
+truncate table seq_notificacao;
+
+truncate table plano_trabalho;
+truncate table seq_plano_trabalho;
+
+truncate table reabertura_programada;
+truncate table seq_reabertura_programada;
+
+truncate table rel_aviso_orgao;
+
+truncate table rel_item_etapa_serie;
+
+truncate table rel_item_etapa_unidade;
+
+truncate table rel_notificacao_documento;
+
+truncate table rel_orgao_pesquisa;
+
+truncate table rel_serie_plano_trabalho;
+
+truncate table rel_usuario_tipo_prioridade;
+
+
+
+/* Se no banco a ser limpo tenha Grupos de E-mail Institucionais configurados na Administração do SEI, verifique a possibilidade de reconfigurá-los manualmente pela aplicação. Caso tenha necessidade de mantê-los no banco, em vez de executar os dois comandos acima, deve executar o comando abaixo para deletar apenas os Grupos de E-mail dos Usuários, não sendo possível o realinhamento dos IDs:
+	delete from grupo_email where sta_tipo='U';
+*/
+
+truncate table grupo_unidade;
+truncate table seq_grupo_unidade;
+
+/* Se no banco a ser limpo tenha Grupos de Envio Institucionais configurados na Administração do SEI, verifique a possibilidade de reconfigurá-los manualmente pela aplicação. Caso tenha necessidade de mantê-los no banco, em vez de executar os dois comandos acima, deve executar o comando abaixo para deletar apenas os Grupos de Envio dos Usuários, não sendo possível o realinhamento dos IDs:
+	delete from grupo_unidade where sta_tipo='U';
+*/
+
+
+/* Reconstrui as tabelas de log e auditoria e tabelas sequenciais correspondentes */
+truncate table infra_auditoria;
+truncate table seq_infra_auditoria;
+
+truncate table infra_log;
+truncate table seq_infra_log;
+
+truncate table infra_navegador;
+truncate table seq_infra_navegador;
+
+truncate table infra_dado_usuario;
+
+
+SET FOREIGN_KEY_CHECKS=1;
+
+
+/* Sobre a última linha abaixo, de acordo com a configuração da fórmula de numeração de protocolo de processo, a tabela de sequência anual de processos pode ser qualquer um dos formatos abaixo:
+	seq_[ano]_org_sip_[id sip]
+	seq_[ano]_org_sei_[cod sei]
+	seq_[ano]_uni_sip_[id sip]
+	seq_[ano]_uni_sei_[cod sei]
+*/
+
+delete from infra_sequencia where nome_tabela like 'seq_%_uni_sei_%';
+delete from infra_sequencia where nome_tabela like 'seq_%_uni_sip_%';
+delete from infra_sequencia where nome_tabela like 'seq_%_org_sei_%';
+delete from infra_sequencia where nome_tabela like 'seq_%_org_sip_%';
+
+update infra_sequencia set num_atual=0 where nome_tabela='infra_log';
+update infra_sequencia set num_atual=0 where nome_tabela='infra_navegador';
+
+/********************************************************************************************************************************************************/
+

--- a/mysql/v4.1.0/utilitarios/sip_script_limpeza_mysql.sql
+++ b/mysql/v4.1.0/utilitarios/sip_script_limpeza_mysql.sql
@@ -1,13 +1,15 @@
 /*
-SCRIPT DE LIMPEZA DE DADOS DA BASE DE DADOS DO SIP - SEI 4.0.0 (PostgreSQL)
+SCRIPT DE LIMPEZA DE DADOS DA BASE DE DADOS DO SIP - SEI 4.1.0 (MySQL)
 */
 
-/* Reconstrui as tabelas de log e auditoria e tabelas sequenciais correspondentes */
+/* Limpeza das tabelas de log e auditoria e tabelas sequenciais correspondentes */
 delete from infra_auditoria;
-select setval ('seq_infra_auditoria', 1);
+
+delete from seq_infra_auditoria;
 
 delete from infra_log;
-select setval ('seq_infra_log', 1);
+
+delete from seq_infra_log;
 
 delete from login;
 
@@ -20,5 +22,15 @@ delete from dispositivo_acesso;
 delete from codigo_acesso;
 
 delete from usuario_historico;
+
+delete from grupo_perfil;
+
+delete from infra_captcha;
+
+delete from infra_captcha_tentativa;
+
+delete from infra_erro_php;
+
+delete from rel_grupo_perfil_perfil;
 
 /********************************************************************************************************************************************************/

--- a/oracle/v4.1.0/utilitarios/sei_script_limpeza_oracle.sql
+++ b/oracle/v4.1.0/utilitarios/sei_script_limpeza_oracle.sql
@@ -1,0 +1,392 @@
+/*
+SCRIPT DE LIMPEZA DE PROCESSOS E DOCUMENTOS DA BASE DE DADOS DO SEI 4.1.0 (ORACLE)
+  Antes de executar o script:
+    1) Retirar o sistema do "AR" (derrubar todas sessoes).
+    2) Fazer uma cópia da base imediatamente antes de executar o script.
+    3) Executar o script de limpeza. Se der erro, restaurar a base com a cópia feita no passo 2.
+
+  Depois de executar o script com sucesso, sendo aconselhável conferir algumas tabelas abaixo e sequenciais de protocolo de processo na tabela "infra_sequencia":
+    1) Apagar todos os arquivos e estrutura de pastas no Filesystem do sei_esquema.
+    2) Excluir os Índices do Solr, conforme orientado no final do capítulo do Solr no Manual de Instalação do SEI:
+      18 - Caso,  no  futuro,  seja  preciso  reindexar  todos  os  dados  é  aconselhável  limpar  antes  os  Índices usando os comandos abaixo:
+        http://[servidor_solr]:8080/solr/sei-protocolos/update?stream.body=<delete><query>*:*</query></delete>&commit=true
+				http://[servidor_solr]:8080/solr/sei-bases-conhecimento/update?stream.body=<delete><query>*:*</query></delete>&commit=true
+				http://[servidor_solr]:8080/solr/sei-publicacoes/update?stream.body=<delete><query>*:*</query></delete>&commit=true
+		4) Colocar o sistema de volta ao "AR".
+*/
+
+connect sei_esquema/sei_esquema@teste
+ 
+/* Limpeza de tabelas afetas a Protocolo de Processos, de Documentos Gerados e Externos */
+
+--Procedure para reiniciar sequence de acordo com o valor máximo da tabela correspondente
+create or replace procedure reset_seq( p_seq_name in varchar2 )
+is
+l_val number;
+begin
+execute immediate 'select ' || p_seq_name || '.nextval from dual' INTO l_val;
+
+execute immediate 'alter sequence ' || p_seq_name || ' increment by -' || l_val || ' minvalue 0';
+
+execute immediate 'select ' || p_seq_name || '.nextval from dual' INTO l_val;
+
+execute immediate 'alter sequence ' || p_seq_name || ' increment by 1 minvalue 0';
+end;
+/
+
+--Início - Desabilitando as FKs
+set echo off 
+set feedback off 
+set verify off 
+set heading off
+set termout off
+set pagesize 1000
+set colwidth 500
+set linesize 500
+spool disable_fk.sql
+select 'ALTER TABLE '||cons.table_name||' DISABLE CONSTRAINT '||constraint_name||' CASCADE;'
+from   user_tables tabs
+       INNER JOIN user_constraints cons on (cons.table_name = tabs.table_name)       
+where cons.CONSTRAINT_TYPE = 'R';
+spool off
+@disable_fk.sql;
+/
+--Fim - Desabilitando as FKs
+
+truncate table anexo;
+exec reset_seq('sei_esquema.seq_anexo');
+
+truncate table numeracao;
+exec reset_seq('sei_esquema.seq_numeracao');
+
+truncate table acesso;
+exec reset_seq('sei_esquema.seq_acesso');
+
+truncate table acesso_externo;
+exec reset_seq('sei_esquema.seq_acesso_externo');
+
+truncate table acompanhamento;
+exec reset_seq('sei_esquema.seq_acompanhamento');
+
+truncate table grupo_acompanhamento;
+exec reset_seq('sei_esquema.seq_grupo_acompanhamento');
+
+truncate table andamento_situacao;
+exec reset_seq('sei_esquema.seq_andamento_situacao');
+
+truncate table anotacao;
+exec reset_seq('sei_esquema.seq_anotacao');
+
+truncate table assinatura;
+exec reset_seq('sei_esquema.seq_assinatura');
+
+truncate table estatisticas;
+exec reset_seq('sei_esquema.seq_estatisticas');
+
+truncate table base_conhecimento;
+exec reset_seq('seq_base_conhecimento');
+
+truncate table rel_base_conhec_tipo_proced;
+
+truncate table versao_secao_documento;
+exec reset_seq('sei_esquema.seq_versao_secao_documento');
+
+truncate table secao_documento;
+exec reset_seq('sei_esquema.seq_secao_documento');
+
+truncate table atributo_andamento;
+exec reset_seq('sei_esquema.seq_atributo_andamento');
+
+truncate table retorno_programado;
+exec reset_seq('sei_esquema.seq_retorno_programado');
+
+truncate table participante;
+exec reset_seq('sei_esquema.seq_participante');
+
+truncate table observacao;
+exec reset_seq('sei_esquema.seq_observacao');
+
+truncate table rel_protocolo_assunto;
+
+truncate table rel_protocolo_protocolo;
+exec reset_seq('sei_esquema.seq_rel_protocolo_protocolo');
+
+truncate table publicacao;
+exec reset_seq('sei_esquema.seq_publicacao');
+
+truncate table rel_bloco_protocolo;
+
+truncate table rel_bloco_unidade;
+
+truncate table protocolo_modelo;
+exec reset_seq('sei_esquema.seq_protocolo_modelo');
+
+truncate table grupo_protocolo_modelo;
+exec reset_seq('seq_grupo_protocolo_modelo');
+
+truncate table unidade_publicacao;
+exec reset_seq('sei_esquema.seq_unidade_publicacao');
+
+truncate table serie_escolha;
+
+truncate table serie_publicacao;
+exec reset_seq('sei_esquema.seq_serie_publicacao');
+
+truncate table texto_padrao_interno;
+exec reset_seq('sei_esquema.seq_texto_padrao_interno');
+
+truncate table rel_protocolo_atributo;
+
+truncate table feed;
+exec reset_seq('sei_esquema.seq_feed');
+
+exec reset_seq('sei_esquema.seq_atributo_andamento_situaca');
+
+truncate table auditoria_protocolo;
+exec reset_seq('sei_esquema.seq_auditoria_protocolo');
+
+truncate table rel_notificacao_documento;
+
+truncate table estatisticas;
+exec reset_seq('sei_esquema.seq_estatisticas');
+
+truncate table atributo_andamento;
+exec reset_seq('sei_esquema.seq_atributo_andamento');
+
+truncate table bloco;
+exec reset_seq('sei_esquema.seq_bloco');
+
+truncate table atividade;
+exec reset_seq('sei_esquema.seq_atividade');
+
+truncate table documento;
+exec reset_seq('sei_esquema.seq_documento');
+
+truncate table procedimento;
+
+truncate table tipo_procedimento_escolha;
+
+truncate table protocolo;
+exec reset_seq('sei_esquema.seq_protocolo');
+
+truncate table email_grupo_email;
+exec reset_seq('sei_esquema.seq_email_grupo_email');
+
+truncate table grupo_email;
+exec reset_seq('sei_esquema.seq_grupo_email');
+
+truncate table acao_federacao;
+
+truncate table acesso_federacao;
+
+truncate table andamento_instalacao;
+exec reset_seq('sei_esquema.seq_andamento_instalacao');
+
+truncate table andamento_marcador;
+exec reset_seq('sei_esquema.seq_andamento_marcador');
+
+truncate table seq_andamento_situacao;
+
+truncate table arquivamento;
+
+truncate table atributo_instalacao;
+exec reset_seq('sei_esquema.seq_atributo_instalacao');
+
+truncate table campo_pesquisa;
+exec reset_seq('sei_esquema.seq_campo_pesquisa');
+
+truncate table categoria;
+exec reset_seq('sei_esquema.seq_categoria');
+
+truncate table comentario;
+exec reset_seq('sei_esquema.seq_comentario');
+
+truncate table controle_prazo;
+exec reset_seq('sei_esquema.seq_controle_prazo');
+
+truncate table documento_conteudo;
+
+truncate table grupo_bloco;
+exec reset_seq('sei_esquema.seq_grupo_bloco');
+
+truncate table grupo_federacao;
+exec reset_seq('sei_esquema.seq_grupo_federacao');
+
+truncate table instalacao_federacao;
+
+truncate table lembrete;
+exec reset_seq('sei_esquema.seq_lembrete');
+
+truncate table mapeamento_assunto;
+
+truncate table marcador;
+exec reset_seq('sei_esquema.seq_marcador');
+
+truncate table monitoramento_servico;
+exec reset_seq('sei_esquema.seq_monitoramento_servico');
+
+truncate table orgao_federacao;
+
+truncate table parametro_acao_federacao;
+
+truncate table pesquisa;
+exec reset_seq('sei_esquema.seq_pesquisa');
+
+truncate table protocolo_federacao;
+
+truncate table rel_acesso_ext_protocolo;
+
+truncate table rel_acesso_ext_serie;
+
+truncate table rel_grupo_fed_orgao_fed;
+
+truncate table rel_usuario_grupo_acomp;
+
+truncate table rel_usuario_grupo_bloco;
+
+truncate table rel_usuario_marcador;
+
+truncate table rel_usuario_tipo_proced;
+
+truncate table rel_usuario_usuario_unidade;
+
+truncate table replicacao_federacao;
+
+truncate table sinalizacao_federacao;
+
+truncate table unidade_federacao;
+
+truncate table usuario_federacao;
+
+truncate table	andamento_plano_trabalho;
+exec reset_seq('sei_esquema.seq_andamento_plano_trabalho');
+
+truncate table atributo_andam_plano_trab;
+exec reset_seq('sei_esquema.seq_atributo_andam_plano_trab');
+
+truncate table avaliacao_documental;
+exec reset_seq('sei_esquema.seq_avaliacao_documental');
+
+truncate table aviso;
+exec reset_seq('sei_esquema.seq_aviso');
+
+truncate table cpad;
+exec reset_seq('sei_esquema.seq_cpad');
+
+truncate table cpad_avaliacao;
+exec reset_seq('sei_esquema.seq_cpad_avaliacao');
+
+truncate table cpad_composicao;
+exec reset_seq('sei_esquema.seq_cpad_composicao');
+
+truncate table cpad_versao;
+exec reset_seq('sei_esquema.seq_cpad_versao');
+
+truncate table documento_geracao;
+
+truncate table edital_eliminacao;
+exec reset_seq('sei_esquema.seq_edital_eliminacao');
+
+truncate table edital_eliminacao_conteudo;
+exec reset_seq('sei_esquema.seq_edital_eliminacao_conteudo');
+
+truncate table edital_eliminacao_erro;
+exec reset_seq('sei_esquema.seq_edital_eliminacao_erro');
+
+truncate table etapa_trabalho;
+exec reset_seq('sei_esquema.seq_etapa_trabalho');
+
+truncate table infra_captcha;
+
+truncate table infra_captcha_tentativa;
+
+truncate table infra_erro_php;
+
+truncate table item_etapa;
+exec reset_seq('sei_esquema.seq_item_etapa');
+
+truncate table notificacao;
+exec reset_seq('sei_esquema.seq_notificacao');
+
+truncate table plano_trabalho;
+exec reset_seq('sei_esquema.seq_plano_trabalho');
+
+truncate table reabertura_programada;
+exec reset_seq('sei_esquema.seq_reabertura_programada');
+
+truncate table rel_aviso_orgao;
+
+truncate table rel_item_etapa_serie;
+
+truncate table rel_item_etapa_unidade;
+
+truncate table rel_notificacao_documento;
+
+truncate table rel_orgao_pesquisa;
+
+truncate table rel_serie_plano_trabalho;
+
+truncate table rel_usuario_tipo_prioridade;
+
+/* Se no banco a ser limpo tenha Grupos de E-mail Institucionais configurados na Administraçã£o do SEI, verifique a possibilidade de reconfigurá-los manualmente pela aplicação. Caso tenha necessidade de mantê-los no banco, em vez de executar os dois comandos acima, deve executar o comando abaixo para deletar apenas os Grupos de E-mail dos Usuários, não sendo possível o realinhamento dos IDs:
+	delete from grupo_email where sta_tipo='U';
+*/
+
+truncate table grupo_unidade;
+exec reset_seq('sei_esquema.seq_grupo_unidade');
+
+
+
+/* Se no banco a ser limpo tenha Grupos de Envio Institucionais configurados na Administração do SEI, verifique a possibilidade de reconfigurá-los manualmente pela aplicação. Caso tenha necessidade de mantê-los no banco, em vez de executar os dois comandos acima, deve executar o comando abaixo para deletar apenas os Grupos de Envio dos Usuários, não sendo possível o realinhamento dos IDs:
+	delete from grupo_unidade where sta_tipo='U';
+*/
+
+
+/* Reconstrui as tabelas de log e auditoria e tabelas sequenciais correspondentes */
+truncate table infra_auditoria;
+exec reset_seq('sei_esquema.seq_infra_auditoria');
+
+truncate table infra_log;
+exec reset_seq('sei_esquema.seq_infra_log');
+
+truncate table infra_navegador;
+exec reset_seq('sei_esquema.seq_infra_navegador');
+
+truncate table infra_dado_usuario;
+
+--Início - Habilitando as FKs
+set echo off 
+set feedback off 
+set verify off 
+set heading off
+set termout off
+set pagesize 1000
+set colwidth 500
+set linesize 500
+spool enable_fk.sql
+select 'ALTER TABLE '||cons.table_name||' ENABLE CONSTRAINT '||constraint_name||';'
+from   user_tables tabs
+       INNER JOIN user_constraints cons on (cons.table_name = tabs.table_name)       
+where cons.CONSTRAINT_TYPE = 'R';
+spool off
+@enable_fk.sql;
+/
+--Fim - Habilitando as FKs
+
+/*
+Sobre a última linha abaixo, a tabela de sequência anual de protocolo de processos pode ser qualquer um dos formatos abaixo (de acordo com a configuração da numeração de protocolo):
+seq_[ano]_org_sip_[id sip]
+seq_[ano]_org_sei_[cod sei]
+seq_[ano]_uni_sip_[id sip]
+seq_[ano]_uni_sei_[cod sei]
+*/
+
+delete from infra_sequencia where nome_tabela like 'seq_%_uni_sei_%';
+delete from infra_sequencia where nome_tabela like 'seq_%_uni_sip_%';
+delete from infra_sequencia where nome_tabela like 'seq_%_org_sei_%';
+delete from infra_sequencia where nome_tabela like 'seq_%_org_sip_%';
+
+update infra_sequencia set num_atual=0 where nome_tabela='infra_log';
+update infra_sequencia set num_atual=0 where nome_tabela='infra_navegador';
+
+/********************************************************************************************************************************************************/

--- a/oracle/v4.1.0/utilitarios/sip_script_limpeza_oracle.sql
+++ b/oracle/v4.1.0/utilitarios/sip_script_limpeza_oracle.sql
@@ -1,0 +1,46 @@
+/*
+SCRIPT DE LIMPEZA DE DADOS DA BASE DE DADOS DO SIP - SEI 4.1.0 (ORACLE)
+*/
+
+--connect sip@sip
+
+/* Limpeza das tabelas de log e auditoria e as sequences correspondentes */
+
+delete from infra_auditoria;
+
+delete from infra_log;
+ 
+alter sequence seq_infra_auditoria increment by 1 minvalue 0;
+
+alter sequence seq_infra_log increment by 1 minvalue 0;
+
+
+delete from login;
+
+delete from usuario_historico;
+
+delete from codigo_bloqueio;
+
+delete from dispositivo_acesso;
+
+delete from codigo_acesso;
+
+delete from recurso_vinculado;
+
+delete from grupo_perfil;
+
+delete from infra_captcha;
+
+delete from infra_captcha_tentativa;
+
+delete from infra_erro_php;
+
+delete from rel_grupo_perfil_perfil;
+
+
+
+
+/********************************************************************************************************************************************************/
+
+
+

--- a/postgresql/v4.1.0/utilitarios/sei_script_limpeza_postgres.sql
+++ b/postgresql/v4.1.0/utilitarios/sei_script_limpeza_postgres.sql
@@ -1,0 +1,368 @@
+/*
+SCRIPT DE LIMPEZA DE PROCESSOS, DOCUMENTOS E OPERAÇÕES DE USUÁRIOS DA BASE DE DADOS DO SEI 4.1.0 (PostgresSQL)    
+	Antes de executar o script:
+		1) Retirar o sistema do "AR" (derrubar todas sessões).
+		2) Fazer uma cópia da base imediatamente antes de executar o script.
+		3) Executar o script de limpeza. Se der erro, restaurar a base com a cópia feita no passo 2.
+	
+	Depois de executar o script com sucesso, sendo aconselhável conferir algumas tabelas abaixo e sequenciais de protocolo de processo na tabela "infra_sequencia":
+		1) Apagar todos os arquivos e estrutura de pastas no Filesystem do SEI.
+		2) Excluir os índices do Solr, conforme orientado no final do capítulo do Solr no Manual de Instalação do SEI:
+			18 - Caso,  no  futuro,  seja  preciso  reindexar  todos  os  dados  é  aconselhável  limpar  antes  os  índices usando os comandos abaixo:
+				http://[servidor_solr]:8080/solr/sei-protocolos/update?stream.body=<delete><query>*:*</query></delete>&commit=true
+				http://[servidor_solr]:8080/solr/sei-bases-conhecimento/update?stream.body=<delete><query>*:*</query></delete>&commit=true
+				http://[servidor_solr]:8080/solr/sei-publicacoes/update?stream.body=<delete><query>*:*</query></delete>&commit=true
+		4) Colocar o sistema de volta ao "AR".
+*/
+
+
+
+/* Limpeza de tabelas afetas a Protocolo de Processos, de Documentos Gerados e Externos e de Operações dos Usuários */
+
+/*SET FOREIGN_KEY_CHECKS=0;*/
+
+DROP FUNCTION fc_habilitar_triggers;
+
+CREATE FUNCTION fc_habilitar_triggers( nome_schema TEXT, habilitar BOOLEAN )
+RETURNS VOID AS 
+$BODY$
+DECLARE
+    tbl RECORD;
+BEGIN
+    FOR tbl IN SELECT schemaname || '.' || tablename AS nome FROM pg_tables WHERE schemaname = nome_schema
+    LOOP
+        IF ( habilitar = TRUE ) THEN
+            EXECUTE 'ALTER TABLE ' || tbl.nome || ' ENABLE TRIGGER ALL';
+        ELSE
+            EXECUTE 'ALTER TABLE ' || tbl.nome || ' DISABLE TRIGGER ALL';
+        END IF;
+    END LOOP;
+
+    RETURN;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
+
+SELECT fc_habilitar_triggers('public', FALSE );
+
+delete from anexo;
+select setval('seq_anexo',1);
+
+delete from numeracao;
+select setval('seq_numeracao',1);
+
+delete from acesso;
+select setval('seq_acesso',1);
+
+delete from acesso_externo;
+select setval('seq_acesso_externo',1);
+
+delete from acompanhamento;
+select setval('seq_acompanhamento',1);
+
+delete from grupo_acompanhamento;
+select setval('seq_grupo_acompanhamento',1);
+
+delete from andamento_situacao;
+select setval('seq_andamento_situacao',1);
+
+delete from anotacao;
+select setval('seq_anotacao',1);
+
+delete from assinatura;
+select setval('seq_assinatura',1);
+
+delete from estatisticas;
+select setval('seq_estatisticas',1);
+
+delete from base_conhecimento;
+select setval('seq_base_conhecimento',1);
+
+delete from rel_base_conhec_tipo_proced;
+
+delete from versao_secao_documento;
+select setval('seq_versao_secao_documento',1);
+
+delete from secao_documento;
+select setval('seq_secao_documento',1);
+
+delete from atributo_andamento;
+select setval('seq_atributo_andamento',1);
+
+delete from retorno_programado;
+select setval('seq_retorno_programado',1);
+
+delete from participante;
+select setval('seq_participante',1);
+
+delete from observacao;
+select setval('seq_observacao',1);
+
+delete from rel_protocolo_assunto;
+
+delete from rel_protocolo_protocolo;
+select setval('seq_rel_protocolo_protocolo',1);
+
+delete from publicacao;
+select setval('seq_publicacao',1);
+
+delete from rel_bloco_protocolo;
+
+delete from rel_bloco_unidade;
+
+delete from protocolo_modelo;
+select setval('seq_protocolo_modelo',1);
+
+delete from grupo_protocolo_modelo;
+select setval('seq_grupo_protocolo_modelo',1);
+
+delete from unidade_publicacao;
+select setval('seq_unidade_publicacao',1);
+
+delete from serie_escolha;
+
+delete from serie_publicacao;
+select setval('seq_serie_publicacao',1);
+
+delete from texto_padrao_interno;
+select setval('seq_texto_padrao_interno',1);
+
+delete from rel_protocolo_atributo;
+
+delete from feed;
+select setval('seq_feed',1);
+
+select setval('seq_atributo_andamento_situaca',1);
+
+delete from auditoria_protocolo;
+select setval('seq_auditoria_protocolo',1);
+
+delete from rel_notificacao_documento;
+
+delete from notificacao;
+
+delete from bloco;
+select setval('seq_bloco',1);
+
+delete from atividade;
+select setval('seq_atividade',1);
+
+delete from documento;
+select setval('seq_documento',1);
+
+delete from procedimento;
+
+delete from tipo_procedimento_escolha;
+
+delete from protocolo;
+select setval('seq_protocolo',1);
+
+delete from email_grupo_email;
+select setval('seq_email_grupo_email',1);
+
+delete from grupo_email;
+select setval('seq_grupo_email',1);
+
+delete from acao_federacao;
+
+delete from acesso_federacao;
+
+delete from andamento_instalacao;
+select setval('seq_andamento_instalacao',1);
+
+delete from andamento_marcador;
+select setval('seq_andamento_marcador',1);
+
+select setval('seq_andamento_situacao',1);
+
+delete from arquivamento;
+
+delete from atributo_instalacao;
+select setval('seq_atributo_instalacao',1);
+
+delete from campo_pesquisa;
+select setval('seq_campo_pesquisa',1);
+
+delete from categoria;
+select setval('seq_categoria',1);
+
+delete from comentario;
+select setval('seq_comentario',1);
+
+delete from controle_prazo;
+select setval('seq_controle_prazo',1);
+
+delete from documento_conteudo;
+
+delete from grupo_bloco;
+select setval('seq_grupo_bloco',1);
+
+delete from grupo_federacao;
+select setval('seq_grupo_federacao',1);
+
+delete from instalacao_federacao;
+
+delete from lembrete;
+select setval('seq_lembrete',1);
+
+delete from mapeamento_assunto;
+
+delete from marcador;
+select setval('seq_marcador',1);
+
+delete from monitoramento_servico;
+select setval('seq_monitoramento_servico',1);
+
+delete from orgao_federacao;
+
+delete from parametro_acao_federacao;
+
+delete from pesquisa;
+select setval('seq_pesquisa',1);
+
+delete from protocolo_federacao;
+
+delete from rel_acesso_ext_protocolo;
+
+delete from rel_acesso_ext_serie;
+
+delete from rel_grupo_fed_orgao_fed;
+
+delete from rel_usuario_grupo_acomp;
+
+delete from rel_usuario_grupo_bloco;
+
+delete from rel_usuario_marcador;
+
+delete from rel_usuario_tipo_proced;
+
+delete from rel_usuario_usuario_unidade;
+
+delete from replicacao_federacao;
+
+delete from sinalizacao_federacao;
+
+delete from unidade_federacao;
+
+delete from usuario_federacao;
+
+delete from andamento_plano_trabalho;
+select setval('seq_andamento_plano_trabalho',1);
+
+delete from atributo_andam_plano_trab;
+select setval('seq_atributo_andam_plano_trab',1);
+
+delete from avaliacao_documental;
+select setval('seq_avaliacao_documental',1);
+
+delete from aviso;
+select setval('seq_aviso',1);
+
+delete from cpad;
+select setval('seq_cpad',1);
+
+delete from cpad_avaliacao;
+select setval('seq_cpad_avaliacao',1);
+
+delete from cpad_composicao;
+select setval('seq_cpad_composicao',1);
+
+delete from cpad_versao;
+select setval('seq_cpad_versao',1);
+
+delete from documento_geracao;
+
+delete from edital_eliminacao;
+select setval('seq_edital_eliminacao',1);
+
+delete from edital_eliminacao_conteudo;
+select setval('seq_edital_eliminacao_conteudo',1);
+
+delete from edital_eliminacao_erro;
+select setval('seq_edital_eliminacao_erro',1);
+
+delete from etapa_trabalho;
+select setval('seq_etapa_trabalho',1);
+
+delete from infra_captcha;
+
+delete from infra_captcha_tentativa;
+
+delete from infra_erro_php;
+
+delete from item_etapa;
+select setval('seq_item_etapa',1);
+
+delete from notificacao;
+select setval('seq_notificacao',1);
+
+delete from plano_trabalho;
+select setval('seq_plano_trabalho',1);
+
+delete from reabertura_programada;
+select setval('seq_reabertura_programada',1);
+
+delete from rel_aviso_orgao;
+
+delete from rel_item_etapa_serie;
+
+delete from rel_item_etapa_unidade;
+
+delete from rel_notificacao_documento;
+
+delete from rel_orgao_pesquisa;
+
+delete from rel_serie_plano_trabalho;
+
+delete from rel_usuario_tipo_prioridade;
+
+
+
+
+/* Se no banco a ser limpo tenha Grupos de E-mail Institucionais configurados na Administração do SEI, verifique a possibilidade de reconfigurá-los manualmente pela aplicação. Caso tenha necessidade de mantê-los no banco, em vez de executar os dois comandos acima, deve executar o comando abaixo para deletar apenas os Grupos de E-mail dos Usuários, não sendo possível o realinhamento dos IDs:
+	delete from grupo_email where sta_tipo='U';
+*/
+
+delete from grupo_unidade;
+select setval('seq_grupo_unidade',1);
+
+/* Se no banco a ser limpo tenha Grupos de Envio Institucionais configurados na Administração do SEI, verifique a possibilidade de reconfigurá-los manualmente pela aplicação. Caso tenha necessidade de mantê-los no banco, em vez de executar os dois comandos acima, deve executar o comando abaixo para deletar apenas os Grupos de Envio dos Usuários, não sendo possível o realinhamento dos IDs:
+	delete from grupo_unidade where sta_tipo='U';
+*/
+
+
+
+/* Reconstrui as tabelas de log e auditoria e tabelas sequenciais correspondentes */
+delete from infra_auditoria;
+select setval('seq_infra_auditoria',1);
+
+delete from infra_log;
+select setval('seq_infra_log',1);
+
+delete from infra_navegador;
+select setval('seq_infra_navegador',1);
+
+delete from infra_dado_usuario;
+
+SELECT fc_habilitar_triggers('public', TRUE );
+
+/*SET FOREIGN_KEY_CHECKS=1;*/
+
+
+/* Sobre a última linha abaixo, de acordo com a configuração da fórmula de numeração de protocolo de processo, a tabela de sequência anual de processos pode ser qualquer um dos formatos abaixo:
+	seq_[ano]_org_sip_[id sip]
+	seq_[ano]_org_sei_[cod sei]
+	seq_[ano]_uni_sip_[id sip]
+	seq_[ano]_uni_sei_[cod sei]
+*/
+
+delete from infra_sequencia where nome_tabela like 'seq_%_uni_sei_%';
+delete from infra_sequencia where nome_tabela like 'seq_%_uni_sip_%';
+delete from infra_sequencia where nome_tabela like 'seq_%_org_sei_%';
+delete from infra_sequencia where nome_tabela like 'seq_%_org_sip_%';
+
+update infra_sequencia set num_atual=0 where nome_tabela='infra_log';
+update infra_sequencia set num_atual=0 where nome_tabela='infra_navegador';
+
+/********************************************************************************************************************************************************/

--- a/postgresql/v4.1.0/utilitarios/sip_script_limpeza_postgres.sql
+++ b/postgresql/v4.1.0/utilitarios/sip_script_limpeza_postgres.sql
@@ -1,8 +1,8 @@
 /*
-SCRIPT DE LIMPEZA DE DADOS DA BASE DE DADOS DO SIP - SEI 4.0.0 (PostgreSQL)
+SCRIPT DE LIMPEZA DE DADOS DA BASE DE DADOS DO SIP - SEI 4.1.0 (PostgreSQL)
 */
 
-/* Reconstrui as tabelas de log e auditoria e tabelas sequenciais correspondentes */
+/* Limpeza das tabelas de log e auditoria e tabelas sequenciais correspondentes */
 delete from infra_auditoria;
 select setval ('seq_infra_auditoria', 1);
 
@@ -20,5 +20,15 @@ delete from dispositivo_acesso;
 delete from codigo_acesso;
 
 delete from usuario_historico;
+
+delete from grupo_perfil;
+
+delete from infra_captcha;
+
+delete from infra_captcha_tentativa;
+
+delete from infra_erro_php;
+
+delete from rel_grupo_perfil_perfil;
 
 /********************************************************************************************************************************************************/

--- a/sqlserver/v4.1.0/utilitarios/sei_script_limpeza_sqlserver.sql
+++ b/sqlserver/v4.1.0/utilitarios/sei_script_limpeza_sqlserver.sql
@@ -1,0 +1,344 @@
+/*
+SCRIPT DE LIMPEZA DE PROCESSOS, DOCUMENTOS E OPERAÇÕES DE USUÁRIOS DA BASE DE DADOS DO SEI 4.1.0 (SQLServer)    
+	Antes de executar o script:
+		1) Retirar o sistema do "AR" (derrubar todas sessões).
+		2) Fazer uma cópia da base imediatamente antes de executar o script.
+		3) Executar o script de limpeza. Se der erro, restaurar a base com a cópia feita no passo 2.
+	
+	Depois de executar o script com sucesso, sendo aconselhável conferir algumas tabelas abaixo e sequenciais de protocolo de processo na tabela "infra_sequencia":
+		1) Apagar todos os arquivos e estrutura de pastas no Filesystem do SEI.
+		2) Excluir os índices do Solr, conforme orientado no final do capítulo do Solr no Manual de Instalação do SEI:
+			18 - Caso,  no  futuro,  seja  preciso  reindexar  todos  os  dados  é  aconselhável  limpar  antes  os  índices usando os comandos abaixo:
+				http://[servidor_solr]:8080/solr/sei-protocolos/update?stream.body=<delete><query>*:*</query></delete>&commit=true
+				http://[servidor_solr]:8080/solr/sei-bases-conhecimento/update?stream.body=<delete><query>*:*</query></delete>&commit=true
+				http://[servidor_solr]:8080/solr/sei-publicacoes/update?stream.body=<delete><query>*:*</query></delete>&commit=true
+		4) Colocar o sistema de volta ao "AR".
+*/
+
+/* Limpeza de tabelas afetas a Protocolo de Processos, de Documentos Gerados e Externos e de Operações dos Usuários */
+
+use sei;
+
+EXEC sp_MSForEachTable 'ALTER TABLE ? NOCHECK CONSTRAINT ALL';
+EXEC sp_MSForEachTable 'ALTER TABLE ? DISABLE TRIGGER ALL';
+
+delete from anexo;
+delete from seq_anexo;
+
+delete from numeracao;
+delete from seq_numeracao;
+
+delete from acesso;
+delete from seq_acesso;
+
+delete from acesso_externo;
+delete from seq_acesso_externo;
+
+delete from acompanhamento;
+delete from seq_acompanhamento;
+
+delete from grupo_acompanhamento;
+delete from seq_grupo_acompanhamento;
+
+delete from andamento_situacao;
+delete from seq_andamento_situacao;
+
+
+delete from anotacao;
+delete from seq_anotacao;
+
+delete from assinatura;
+delete from seq_assinatura;
+
+delete from estatisticas;
+delete from seq_estatisticas;
+
+
+delete from base_conhecimento;
+delete from seq_base_conhecimento;
+
+delete from rel_base_conhec_tipo_proced;
+
+
+delete from versao_secao_documento;
+delete from seq_versao_secao_documento;
+
+delete from secao_documento;
+delete from seq_secao_documento;
+
+delete from atributo_andamento;
+delete from seq_atributo_andamento;
+
+delete from retorno_programado;
+delete from seq_retorno_programado;
+
+delete from participante;
+delete from seq_participante;
+
+delete from observacao;
+delete from seq_observacao;
+
+delete from rel_protocolo_assunto;
+
+delete from rel_protocolo_protocolo;
+delete from seq_rel_protocolo_protocolo;
+
+delete from publicacao;
+delete from seq_publicacao;
+
+delete from rel_bloco_protocolo;
+
+delete from rel_bloco_unidade;
+
+delete from protocolo_modelo;
+delete from seq_protocolo_modelo;
+
+delete from grupo_protocolo_modelo;
+delete from seq_grupo_protocolo_modelo;
+
+delete from unidade_publicacao;
+delete from seq_unidade_publicacao;
+
+delete from serie_escolha;
+
+delete from serie_publicacao;
+delete from seq_serie_publicacao;
+
+delete from texto_padrao_interno;
+delete from seq_texto_padrao_interno;
+
+delete from rel_protocolo_atributo;
+
+delete from feed;
+delete from seq_feed;
+
+delete from seq_atributo_andamento_situaca;
+
+delete from auditoria_protocolo;
+delete from seq_auditoria_protocolo;
+
+delete from rel_notificacao_documento;
+
+delete from bloco;
+delete from seq_bloco;
+
+delete from atividade;
+delete from seq_atividade;
+
+delete from documento;
+delete from seq_documento;
+
+delete from procedimento;
+
+delete from tipo_procedimento_escolha;
+
+delete from protocolo;
+delete from seq_protocolo;
+
+delete from email_grupo_email;
+delete from seq_email_grupo_email;
+
+delete from grupo_email;
+delete from seq_grupo_email;
+
+delete from acao_federacao;
+
+delete from acesso_federacao;
+
+delete from andamento_instalacao;
+delete from seq_andamento_instalacao;
+
+delete from andamento_marcador;
+delete from seq_andamento_marcador;
+
+delete from seq_andamento_situacao;
+
+delete from arquivamento;
+
+delete from atributo_instalacao;
+delete from seq_atributo_instalacao;
+
+delete from campo_pesquisa;
+delete from seq_campo_pesquisa;
+
+delete from categoria;
+delete from seq_categoria;
+
+delete from comentario;
+delete from seq_comentario;
+
+delete from controle_prazo;
+delete from seq_controle_prazo;
+
+delete from documento_conteudo;
+
+delete from grupo_bloco;
+delete from seq_grupo_bloco;
+
+delete from grupo_federacao;
+delete from seq_grupo_federacao;
+
+delete from instalacao_federacao;
+
+delete from lembrete;
+delete from seq_lembrete;
+
+delete from mapeamento_assunto;
+
+delete from marcador;
+delete from seq_marcador;
+
+delete from monitoramento_servico;
+delete from seq_monitoramento_servico;
+
+delete from orgao_federacao;
+
+delete from parametro_acao_federacao;
+
+delete from pesquisa;
+delete from seq_pesquisa;
+
+delete from protocolo_federacao;
+
+delete from rel_acesso_ext_protocolo;
+
+delete from rel_acesso_ext_serie;
+
+delete from rel_grupo_fed_orgao_fed;
+
+delete from rel_usuario_grupo_acomp;
+
+delete from rel_usuario_grupo_bloco;
+
+delete from rel_usuario_marcador;
+
+delete from rel_usuario_tipo_proced;
+
+delete from rel_usuario_usuario_unidade;
+
+delete from replicacao_federacao;
+
+delete from sinalizacao_federacao;
+
+delete from unidade_federacao;
+
+delete from usuario_federacao;
+
+delete from andamento_plano_trabalho;
+delete from seq_andamento_plano_trabalho;
+
+delete from atributo_andam_plano_trab;
+delete from seq_atributo_andam_plano_trab;
+
+delete from avaliacao_documental;
+delete from seq_avaliacao_documental;
+
+delete from aviso;
+delete from seq_aviso;
+
+delete from cpad;
+delete from seq_cpad;
+
+delete from cpad_avaliacao;
+delete from seq_cpad_avaliacao;
+
+delete from cpad_composicao;
+delete from seq_cpad_composicao;
+
+delete from cpad_versao;
+delete from seq_cpad_versao;
+
+delete from documento_geracao;
+
+delete from edital_eliminacao;
+delete from seq_edital_eliminacao;
+
+delete from edital_eliminacao_conteudo;
+delete from seq_edital_eliminacao_conteudo;
+
+delete from edital_eliminacao_erro;
+delete from seq_edital_eliminacao_erro;
+
+delete from etapa_trabalho;
+delete from seq_etapa_trabalho;
+
+delete from infra_captcha;
+
+delete from infra_captcha_tentativa;
+
+delete from infra_erro_php;
+
+delete from item_etapa;
+
+delete from seq_item_etapa;
+
+delete from notificacao;
+delete from seq_notificacao;
+
+delete from plano_trabalho;
+delete from seq_plano_trabalho;
+
+delete from reabertura_programada;
+delete from seq_reabertura_programada;
+
+delete from rel_aviso_orgao;
+
+delete from rel_item_etapa_serie;
+
+delete from rel_item_etapa_unidade;
+
+delete from rel_notificacao_documento;
+
+delete from rel_orgao_pesquisa;
+
+delete from rel_serie_plano_trabalho;
+
+delete from rel_usuario_tipo_prioridade;
+
+
+/* Se no banco a ser limpo tenha Grupos de E-mail Institucionais configurados na Administração do SEI, verifique a possibilidade de reconfigurá-los manualmente pela aplicação. Caso tenha necessidade de mantê-los no banco, em vez de executar os dois comandos acima, deve executar o comando abaixo para deletar apenas os Grupos de E-mail dos Usuários, não sendo possível o realinhamento dos IDs:
+	delete from grupo_email where sta_tipo='U';
+*/
+
+delete from grupo_unidade;
+delete from seq_grupo_unidade;
+
+/* Se no banco a ser limpo tenha Grupos de Envio Institucionais configurados na Administração do SEI, verifique a possibilidade de reconfigurá-los manualmente pela aplicação. Caso tenha necessidade de mantê-los no banco, em vez de executar os dois comandos acima, deve executar o comando abaixo para deletar apenas os Grupos de Envio dos Usuários, não sendo possível o realinhamento dos IDs:
+	delete from grupo_unidade where sta_tipo='U';
+*/
+
+
+/* Reconstrui as tabelas de log e auditoria e tabelas sequenciais correspondentes */
+delete from infra_auditoria;
+delete from seq_infra_auditoria;
+
+delete from infra_log;
+delete from seq_infra_log;
+
+delete from infra_navegador;
+delete from seq_infra_navegador;
+
+delete from infra_dado_usuario;
+
+EXEC sp_MSForEachTable 'ALTER TABLE ? CHECK CONSTRAINT ALL';
+EXEC sp_MSForEachTable 'ALTER TABLE ? ENABLE TRIGGER ALL';
+
+
+
+/* Sobre a última linha abaixo, de acordo com a configuração da fórmula de numeração de protocolo de processo, a tabela de sequência anual de processos pode ser qualquer um dos formatos abaixo:
+	seq_[ano]org_sip[id sip]
+	seq_[ano]org_sei[cod sei]
+	seq_[ano]uni_sip[id sip]
+	seq_[ano]uni_sei[cod sei]
+*/
+
+delete from infra_sequencia where nome_tabela like 'seq_%uni_sei%';
+delete from infra_sequencia where nome_tabela like 'seq_%uni_sip%';
+delete from infra_sequencia where nome_tabela like 'seq_%org_sei%';
+delete from infra_sequencia where nome_tabela like 'seq_%org_sip%';
+
+update infra_sequencia set num_atual=0 where nome_tabela='infra_log';
+update infra_sequencia set num_atual=0 where nome_tabela='infra_navegador';
+
+
+

--- a/sqlserver/v4.1.0/utilitarios/sip_script_limpeza_sqlserver.sql
+++ b/sqlserver/v4.1.0/utilitarios/sip_script_limpeza_sqlserver.sql
@@ -1,13 +1,15 @@
 /*
-SCRIPT DE LIMPEZA DE DADOS DA BASE DE DADOS DO SIP - SEI 4.0.0 (PostgreSQL)
+SCRIPT DE LIMPEZA DE DADOS DA BASE DE DADOS DO SIP - SEI 4.1.0 (SqlServer)
 */
 
-/* Reconstrui as tabelas de log e auditoria e tabelas sequenciais correspondentes */
+/* Limpeza das tabelas de log e auditoria e tabelas sequenciais correspondentes */
 delete from infra_auditoria;
-select setval ('seq_infra_auditoria', 1);
+
+delete from seq_infra_auditoria;
 
 delete from infra_log;
-select setval ('seq_infra_log', 1);
+
+delete from  seq_infra_log;
 
 delete from login;
 
@@ -20,5 +22,15 @@ delete from dispositivo_acesso;
 delete from codigo_acesso;
 
 delete from usuario_historico;
+
+delete from grupo_perfil;
+
+delete from infra_captcha;
+
+delete from infra_captcha_tentativa;
+
+delete from infra_erro_php;
+
+delete from rel_grupo_perfil_perfil;
 
 /********************************************************************************************************************************************************/


### PR DESCRIPTION
O bloco de atualizações incorpora novos scripts de limpeza das bases de dados SEI e SIP para a versão 4.1.0, sobre a base de referência do Poder Executivo Federal, para MySQL, SQL Server, Oracle e PostgreSQL. 
Aplica também pequenas correções ao script de limpeza para a base de dados em PostgreSQL, na versão 4.0.0.